### PR TITLE
Require SOAP extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     }
   ],
   "require": {
-    "php": ">=5.4"
+    "php": ">=5.4",
+    "ext-soap": "*"
   },
   "require-dev": {
     "mockery/mockery": "0.9.*",


### PR DESCRIPTION
The `Soap/SoapClient` class extends the `SoapClient` class in the global namespace, which is not part of the PHP core, but the SOAP extension. This change makes sure composer checks if that extension is installed.